### PR TITLE
Update to FreeBSD-13.0-RELEASE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,14 +26,14 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
     - name: Upload Release Asset
       if: "contains(github.ref, 'refs/tags/')"
-      id: upload-release-asset 
+      id: upload-release-asset
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.get_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: ./freebsd-12.2.7z
-        asset_name: freebsd-12.2.7z
+        upload_url: ${{ steps.get_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+        asset_path: ./freebsd-13.0.7z
+        asset_name: freebsd-13.0.7z
         asset_content_type: application/x-7z-compressed
 
 

--- a/index.js
+++ b/index.js
@@ -84,8 +84,8 @@ async function run() {
 
 
 
-    let imgName = "FreeBSD-12.2-RELEASE-amd64";
-    let url = "https://download.freebsd.org/ftp/releases/VM-IMAGES/12.2-RELEASE/amd64/Latest/" + imgName + ".vhd.xz";
+    let imgName = "FreeBSD-13.0-RELEASE-amd64";
+    let url = "https://download.freebsd.org/ftp/releases/VM-IMAGES/13.0-RELEASE/amd64/Latest/" + imgName + ".vhd.xz";
     core.info("Downloading image: " + url);
     let img = await tc.downloadTool(url);
     core.info("Downloaded file: " + img);
@@ -159,13 +159,13 @@ async function run() {
       }
     }
 
-    let ova = "freebsd-12.2.ova";
+    let ova = "freebsd-13.0.ova";
     core.info("Export " + ova);
     await vboxmanage(vmName, "export", "--output " + ova);
     await exec.exec("sudo chmod 666 " + ova);
 
     core.info("Compress " + vhd);
-    await exec.exec("7z a freebsd-12.2.7z  id_rsa.pub " + ova);
+    await exec.exec("7z a freebsd-13.0.7z  id_rsa.pub " + ova);
 
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
FreeBSD-13.0-RELEASE released on 13.04.2021. It's a great release. Let's switch on it.
https://www.freebsd.org/releases/13.0R/announce/