### PR TITLE
Enable serial console

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -161,6 +161,15 @@ echo >>enablessh.local
 $vmsh inputFile $osname enablessh.local
 
 ssh $osname sh <<EOF
+cat <<CONF > /boot/loader.conf
+boot_multicons=YES
+boot_serial=YES
+comconsole_speed=9600
+CONF
+
+EOF
+
+ssh $osname sh <<EOF
 echo 'StrictHostKeyChecking=accept-new' >.ssh/config
 
 echo "Host host" >>.ssh/config


### PR DESCRIPTION
Enable serial console so boot status/information can be obtained programmatically.

The boot loader config just needs to be set to output to any attached serial consoles since it just defaults to video. This doesn't prevent video from working.

Some details:
https://forums.freebsd.org/threads/i-lose-serial-console-during-bootup.83446/#post-548019
https://wiki.freebsd.org/SerialConsole

This should be first step for https://github.com/vmactions/vbox/issues/1